### PR TITLE
wifi: Interface.Frequencies

### DIFF
--- a/wifi.go
+++ b/wifi.go
@@ -123,6 +123,9 @@ type Interface struct {
 
 	// The interface's wireless frequency in MHz.
 	Frequency int
+
+	// Frequencies available to the PHY in MHz.
+	Frequencies map[int]struct{}
 }
 
 // StationInfo contains statistics about a WiFi interface operating in


### PR DESCRIPTION
Scan PHY channels on Interface enumeration and store into Frequencies.

I'm using this to distinguish between channels available among 802.11n and 802.11ac devices.