### PR TITLE
wifi: Fix signal strength scaling (bug #11)

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -5,7 +5,6 @@ package wifi
 import (
 	"bytes"
 	"errors"
-	"math"
 	"net"
 	"os"
 	"time"
@@ -365,9 +364,9 @@ func (info *StationInfo) parseAttributes(attrs []netlink.Attribute) error {
 		case nl80211.StaInfoTxBytes64:
 			info.TransmittedBytes = int(nlenc.Uint64(a.Data))
 		case nl80211.StaInfoSignal:
-			// Converted into the typical negative strength format
 			//  * @NL80211_STA_INFO_SIGNAL: signal strength of last received PPDU (u8, dBm)
-			info.Signal = int(a.Data[0]) - math.MaxUint8
+			// Should just be cast to int8, see code here: https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/tree/station.c#n378
+			info.Signal = int(int8(a.Data[0]))
 		case nl80211.StaInfoRxPackets:
 			info.ReceivedPackets = int(nlenc.Uint32(a.Data))
 		case nl80211.StaInfoTxPackets:

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net"
 	"os"
 	"reflect"
@@ -537,7 +536,7 @@ func (s *StationInfo) attributes() []netlink.Attribute {
 				{Type: nl80211.StaInfoRxBytes64, Data: nlenc.Uint64Bytes(uint64(s.ReceivedBytes))},
 				{Type: nl80211.StaInfoTxBytes, Data: nlenc.Uint32Bytes(uint32(s.TransmittedBytes))},
 				{Type: nl80211.StaInfoTxBytes64, Data: nlenc.Uint64Bytes(uint64(s.TransmittedBytes))},
-				{Type: nl80211.StaInfoSignal, Data: []byte{uint8(s.Signal) + math.MaxUint8}},
+				{Type: nl80211.StaInfoSignal, Data: []byte{byte(int8(s.Signal))}},
 				{Type: nl80211.StaInfoRxPackets, Data: nlenc.Uint32Bytes(uint32(s.ReceivedPackets))},
 				{Type: nl80211.StaInfoTxPackets, Data: nlenc.Uint32Bytes(uint32(s.TransmittedPackets))},
 				{Type: nl80211.StaInfoTxRetries, Data: nlenc.Uint32Bytes(uint32(s.TransmitRetries))},


### PR DESCRIPTION
Fix wifi signal strength scaling, which currently overflows when rssi=0.  See example code here: https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/tree/station.c#n378