### PR TITLE
Add minimal Connect() implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,6 +35,11 @@ func (c *Client) Close() error {
 	return c.c.Close()
 }
 
+// Connect starts connecting the interface to the specified ssid.
+func (c *Client) Connect(ifi *Interface, ssid string) error {
+	return c.c.Connect(ifi, ssid)
+}
+
 // Interfaces returns a list of the system's WiFi network interfaces.
 func (c *Client) Interfaces() ([]*Interface, error) {
 	return c.c.Interfaces()
@@ -56,4 +61,5 @@ type osClient interface {
 	Interfaces() ([]*Interface, error)
 	BSS(ifi *Interface) (*BSS, error)
 	StationInfo(ifi *Interface) ([]*StationInfo, error)
+	Connect(ifi *Interface, ssid string) error
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -5,6 +5,7 @@ package wifi
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"time"
@@ -87,6 +88,39 @@ func (c *client) Interfaces() ([]*Interface, error) {
 	}
 
 	return parseInterfaces(msgs)
+}
+
+// Connect starts connecting the interface to the specified ssid.
+func (c *client) Connect(ifi *Interface, ssid string) error {
+	// Ask nl80211 to connect to the specified SSID.
+	b, err := netlink.MarshalAttributes(
+		[]netlink.Attribute{
+			{
+				Type: nl80211.AttrIfindex,
+				Data: nlenc.Uint32Bytes(uint32(ifi.Index)),
+			},
+
+			{
+				Type: nl80211.AttrSsid,
+				Data: []byte(ssid),
+			},
+		})
+	if err != nil {
+		return err
+	}
+	req := genetlink.Message{
+		Header: genetlink.Header{
+			Command: nl80211.CmdConnect,
+			Version: c.familyVersion,
+		},
+		Data: b,
+	}
+
+	flags := netlink.Request | netlink.Acknowledge
+	if _, err := c.c.Execute(req, c.familyID, flags); err != nil {
+		return err
+	}
+	return nil
 }
 
 // BSS requests that nl80211 return the BSS for the specified Interface.


### PR DESCRIPTION
This is equivalent to e.g. “iw wlan0 connect myssid” and therefore only good for
unencrypted networks. In fact, there are a bunch of optional attributes that can
be set:
https://git.sipsolutions.net/iw.git/tree/connect.c?h=v5.4&id=d5b145c51cd35d6ca4079fd16225c48541cfd8bc#n12

related to https://github.com/gokrazy/gokrazy/issues/57