### PR TITLE
explicitly specify NL80211_ATTR_AUTH_TYPE when joining an open SSID

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -102,6 +102,10 @@ func (c *client) Connect(ifi *Interface, ssid string) error {
 			Type: unix.NL80211_ATTR_SSID,
 			Data: []byte(ssid),
 		},
+		{
+			Type: unix.NL80211_ATTR_AUTH_TYPE,
+			Data: nlenc.Uint32Bytes(unix.NL80211_AUTHTYPE_OPEN_SYSTEM),
+		},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes connecting to open SSIDs on my Raspberry Pi Zero 2 W.

related to https://github.com/gokrazy/gokrazy/issues/96

I also checked that the Raspberry Pi 3 B still connects as before.