### PR TITLE
Parse BSS Load Information Elements

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -557,13 +557,13 @@ func decodeSSID(b []byte) string {
 func decodeBSSLoad(b []byte) (*BSSLoad, error) {
 	var load BSSLoad
 	if len(b) == 5 {
-		// Wiresahrk calls this "802.11e CCA Version"
+		// Wireshark calls this "802.11e CCA Version"
 		load.Version = 2
 		load.StationCount = binary.LittleEndian.Uint16(b[0:2])               // first 2 bytes
 		load.ChannelUtilization = b[2]                                       // next 1 byte
 		load.AvailableAdmissionCapacity = binary.LittleEndian.Uint16(b[3:5]) // last 2 bytes
 	} else if len(b) == 4 {
-		// Wiresahrk calls this "Cisco QBSS Version 1 - non CCA"
+		// Wireshark calls this "Cisco QBSS Version 1 - non CCA"
 		load.Version = 1
 		load.StationCount = binary.LittleEndian.Uint16(b[0:2]) // first 2 bytes
 		load.ChannelUtilization = b[2]                         // next 1 byte

--- a/client_linux.go
+++ b/client_linux.go
@@ -552,21 +552,22 @@ func decodeSSID(b []byte) string {
 	return buf.String()
 }
 
-// func decodeBSSLoad(b []byte) (stationCount uint16, channelUtilization uint8, availableAdmissionCapacity uint1) {
+// decodeBSSLoad Decodes the BSSLoad IE. Supports Version 1 and Version 2
+// values according to https://raw.githubusercontent.com/wireshark/wireshark/master/epan/dissectors/packet-ieee80211.c
 func decodeBSSLoad(b []byte) (*BSSLoad, error) {
-	// values from https://raw.githubusercontent.com/wireshark/wireshark/master/epan/dissectors/packet-ieee80211.c
-	// TODO(lukas-mbag) add error handling
 	var load BSSLoad
 	if len(b) == 5 {
+		// Wiresahrk calls this "802.11e CCA Version"
 		load.Version = 2
-		load.StationCount = binary.LittleEndian.Uint16(b[0:])
-		load.ChannelUtilization = b[2]
-		load.AvailableAdmissionCapacity = binary.LittleEndian.Uint16(b[3:])
+		load.StationCount = binary.LittleEndian.Uint16(b[0:2])               // first 2 bytes
+		load.ChannelUtilization = b[2]                                       // next 1 byte
+		load.AvailableAdmissionCapacity = binary.LittleEndian.Uint16(b[3:5]) // last 2 bytes
 	} else if len(b) == 4 {
+		// Wiresahrk calls this "Cisco QBSS Version 1 - non CCA"
 		load.Version = 1
-		load.StationCount = binary.LittleEndian.Uint16(b[0:])
-		load.ChannelUtilization = b[2]
-		load.AvailableAdmissionCapacity = uint16(b[3])
+		load.StationCount = binary.LittleEndian.Uint16(b[0:2]) // first 2 bytes
+		load.ChannelUtilization = b[2]                         // next 1 byte
+		load.AvailableAdmissionCapacity = uint16(b[3])         // next 1 byte
 	} else {
 		err := errInvalidBSSLoad
 		return nil, err

--- a/client_linux.go
+++ b/client_linux.go
@@ -554,10 +554,13 @@ func decodeSSID(b []byte) string {
 
 // decodeBSSLoad Decodes the BSSLoad IE. Supports Version 1 and Version 2
 // values according to https://raw.githubusercontent.com/wireshark/wireshark/master/epan/dissectors/packet-ieee80211.c
+// See also source code of iw (v5.19) scan.c Line 1634ff
+// BSS Load ELement (with length 5) is defined by chapter 9.4.2.27 (page 1066) of the current IEEE 802.11-2020
 func decodeBSSLoad(b []byte) (*BSSLoad, error) {
 	var load BSSLoad
 	if len(b) == 5 {
 		// Wireshark calls this "802.11e CCA Version"
+		// This is the version defined in IEEE 802.11 (Versions 2007, 2012, 2016 and 2020)
 		load.Version = 2
 		load.StationCount = binary.LittleEndian.Uint16(b[0:2])               // first 2 bytes
 		load.ChannelUtilization = b[2]                                       // next 1 byte

--- a/client_linux.go
+++ b/client_linux.go
@@ -572,8 +572,7 @@ func decodeBSSLoad(b []byte) (*BSSLoad, error) {
 		load.ChannelUtilization = b[2]                         // next 1 byte
 		load.AvailableAdmissionCapacity = uint16(b[3])         // next 1 byte
 	} else {
-		err := errInvalidBSSLoad
-		return nil, err
+		return nil, errInvalidBSSLoad
 	}
 	return &load, nil
 }

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -554,3 +554,40 @@ func mustMessages(t *testing.T, command uint8, want interface{}) genltest.Func {
 		return msgs, nil
 	}
 }
+
+func Test_decodeBSSLoad(t *testing.T) {
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name                           string
+		args                           args
+		wantVersion                    uint16
+		wantStationCount               uint16
+		wantChannelUtilization         uint8
+		wantAvailableAdmissionCapacity uint16
+	}{
+		{name: "Parse BSS Load", args: args{b: []byte{3, 0, 8, 0x8D, 0x5B}}, wantVersion: 2, wantStationCount: 3, wantChannelUtilization: 8, wantAvailableAdmissionCapacity: 23437},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bssLoad, _ := decodeBSSLoad(tt.args.b)
+			gotVersion := bssLoad.Version
+			gotStationCount := bssLoad.StationCount
+			gotChannelUtilization := bssLoad.ChannelUtilization
+			gotAvailableAdmissionCapacity := bssLoad.AvailableAdmissionCapacity
+			if uint16(gotVersion) != tt.wantVersion {
+				t.Errorf("decodeBSSLoad() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
+			}
+			if gotStationCount != tt.wantStationCount {
+				t.Errorf("decodeBSSLoad() gotStationCount = %v, want %v", gotStationCount, tt.wantStationCount)
+			}
+			if gotChannelUtilization != tt.wantChannelUtilization {
+				t.Errorf("decodeBSSLoad() gotChannelUtilization = %v, want %v", gotChannelUtilization, tt.wantChannelUtilization)
+			}
+			if gotAvailableAdmissionCapacity != tt.wantAvailableAdmissionCapacity {
+				t.Errorf("decodeBSSLoad() gotAvailableAdmissionCapacity = %v, want %v", gotAvailableAdmissionCapacity, tt.wantAvailableAdmissionCapacity)
+			}
+		})
+	}
+}

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -567,7 +567,8 @@ func Test_decodeBSSLoad(t *testing.T) {
 		wantChannelUtilization         uint8
 		wantAvailableAdmissionCapacity uint16
 	}{
-		{name: "Parse BSS Load", args: args{b: []byte{3, 0, 8, 0x8D, 0x5B}}, wantVersion: 2, wantStationCount: 3, wantChannelUtilization: 8, wantAvailableAdmissionCapacity: 23437},
+		{name: "Parse BSS Load Normal", args: args{b: []byte{3, 0, 8, 0x8D, 0x5B}}, wantVersion: 2, wantStationCount: 3, wantChannelUtilization: 8, wantAvailableAdmissionCapacity: 23437},
+		{name: "Parse BSS Load Version 1", args: args{b: []byte{9, 0, 8, 0x8D}}, wantVersion: 1, wantStationCount: 9, wantChannelUtilization: 8, wantAvailableAdmissionCapacity: 141},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -589,5 +590,13 @@ func Test_decodeBSSLoad(t *testing.T) {
 				t.Errorf("decodeBSSLoad() gotAvailableAdmissionCapacity = %v, want %v", gotAvailableAdmissionCapacity, tt.wantAvailableAdmissionCapacity)
 			}
 		})
+	}
+}
+
+func Test_decodeBSSLoadError(t *testing.T) {
+	t.Parallel()
+	_, err := decodeBSSLoad([]byte{3, 0, 8})
+	if err == nil {
+		t.Error("want error on bogus IE with wrong length")
 	}
 }

--- a/wifi.go
+++ b/wifi.go
@@ -171,16 +171,16 @@ type StationInfo struct {
 
 // BSSLoad is an Information Element containing measurements of the load on the BSS.
 type BSSLoad struct {
-	// Version of the BSS Load Element. Can be 1 or 2.
+	// Version: Indicates the version of the BSS Load Element. Can be 1 or 2.
 	Version int
 
 	// StationCount: total number of STA currently associated with this BSS.
 	StationCount uint16
 
-	// Channel Utilization: Percentage of time (linearly scaled 0 to 255) that the AP sensed the medium was busy. Calculated only for the primary channel.
+	// ChannelUtilization: Percentage of time (linearly scaled 0 to 255) that the AP sensed the medium was busy. Calculated only for the primary channel.
 	ChannelUtilization uint8
 
-	// Available Admission Capacity: remaining amount of medium time availible via explicit admission controll in units of 32 us/s.
+	// AvailableAdmissionCapacity: remaining amount of medium time availible via explicit admission controll in units of 32 us/s.
 	AvailableAdmissionCapacity uint16
 }
 
@@ -205,21 +205,21 @@ type BSS struct {
 	// The service set identifier, or "network name" of the BSS.
 	SSID string
 
-	// The BSS service set identifier.  In infrastructure mode, this is the
+	// BSSID: The BSS service set identifier.  In infrastructure mode, this is the
 	// hardware address of the wireless access point that a client is associated
 	// with.
 	BSSID net.HardwareAddr
 
-	// The frequency used by the BSS, in MHz.
+	// Frequency: The frequency used by the BSS, in MHz.
 	Frequency int
 
-	// The interval between beacon transmissions for this BSS.
+	// BeaconInterval: The time interval between beacon transmissions for this BSS.
 	BeaconInterval time.Duration
 
-	// The time since the client last scanned this BSS's information.
+	// LastSeen: The time since the client last scanned this BSS's information.
 	LastSeen time.Duration
 
-	// The status of the client within the BSS.
+	// Status: The status of the client within the BSS.
 	Status BSSStatus
 
 	// Load: The load element of the BSS (contains StationCount, ChannelUtilization and AvailableAdmissionCapacity).

--- a/wifi.go
+++ b/wifi.go
@@ -10,6 +10,9 @@ import (
 // errInvalidIE is returned when one or more IEs are malformed.
 var errInvalidIE = errors.New("invalid 802.11 information element")
 
+// errInvalidBSSLoad is returned when BSSLoad IE has wrong length.
+var errInvalidBSSLoad = errors.New("802.11 information element BSSLoad has wrong length")
+
 // An InterfaceType is the operating mode of an Interface.
 type InterfaceType int
 
@@ -166,6 +169,31 @@ type StationInfo struct {
 	BeaconLoss int
 }
 
+// BSSLoad is an Information Element containing Measurements of the Load on the BSS
+type BSSLoad struct {
+	// Version of the BSS Load Element. Can be 1 or 2.
+	Version int
+
+	// Station Count on this BSS
+	StationCount uint16
+
+	// Channel Utilization from 0 to 255
+	ChannelUtilization uint8
+
+	// Available Admission Capacity in unit [32 us/s]
+	AvailableAdmissionCapacity uint16
+}
+
+// String returns the string representation of a BSSLoad.
+func (l BSSLoad) String() string {
+	return fmt.Sprintf("BSSLoad Version: %d    stationCount: %d    channelUtilization: %d/255     availableAdmissionCapacity: %d [*32us/s]\n",
+		l.Version,
+		l.StationCount,
+		l.ChannelUtilization,
+		l.AvailableAdmissionCapacity,
+	)
+}
+
 // A BSS is an 802.11 basic service set.  It contains information about a wireless
 // network associated with an Interface.
 type BSS struct {
@@ -190,17 +218,7 @@ type BSS struct {
 	Status BSSStatus
 
 	// BSSLoad elements
-	// Version of the BSS Load Element. Can be 1 or 2.
-	LoadVersion int
-
-	// Station Count on this BSS
-	LoadStationCount uint16
-
-	// Channel Utilization from 0 to 255
-	LoadChannelUtilization uint8
-
-	// Available Admission Capacity in unit [32 us/s]
-	LoadAvailableAdmissionCapacity uint16
+	Load BSSLoad
 }
 
 // A BSSStatus indicates the current status of client within a BSS.

--- a/wifi.go
+++ b/wifi.go
@@ -186,12 +186,17 @@ type BSSLoad struct {
 
 // String returns the string representation of a BSSLoad.
 func (l BSSLoad) String() string {
-	return fmt.Sprintf("BSSLoad Version: %d    stationCount: %d    channelUtilization: %d/255     availableAdmissionCapacity: %d [*32us/s]\n",
-		l.Version,
-		l.StationCount,
-		l.ChannelUtilization,
-		l.AvailableAdmissionCapacity,
-	)
+	if l.Version == 1 {
+		return fmt.Sprintf("BSSLoad Version: %d    stationCount: %d    channelUtilization: %d/255     availableAdmissionCapacity: %d\n",
+			l.Version, l.StationCount, l.ChannelUtilization, l.AvailableAdmissionCapacity,
+		)
+	} else if l.Version == 2 {
+		return fmt.Sprintf("BSSLoad Version: %d    stationCount: %d    channelUtilization: %d/255     availableAdmissionCapacity: %d [*32us/s]\n",
+			l.Version, l.StationCount, l.ChannelUtilization, l.AvailableAdmissionCapacity,
+		)
+	} else {
+		return fmt.Sprintf("invalid BSSLoad Version: %d", l.Version)
+	}
 }
 
 // A BSS is an 802.11 basic service set.  It contains information about a wireless

--- a/wifi.go
+++ b/wifi.go
@@ -174,13 +174,13 @@ type BSSLoad struct {
 	// Version of the BSS Load Element. Can be 1 or 2.
 	Version int
 
-	// Station Count on this BSS.
+	// Station Count: total number of STA currently associated with this BSS.
 	StationCount uint16
 
-	// Channel Utilization from 0 to 255
+	// Channel Utilization: Percentage of time (linearly scaled 0 to 255) that the AP sensed the medium was busy. Calculated only for the primary channel.
 	ChannelUtilization uint8
 
-	// Available Admission Capacity in unit [32 us/s]
+	// Available Admission Capacity: remaining amount of medium time availible via explicit admission controll in units of 32 us/s.
 	AvailableAdmissionCapacity uint16
 }
 

--- a/wifi.go
+++ b/wifi.go
@@ -174,7 +174,7 @@ type BSSLoad struct {
 	// Version of the BSS Load Element. Can be 1 or 2.
 	Version int
 
-	// Station Count: total number of STA currently associated with this BSS.
+	// StationCount: total number of STA currently associated with this BSS.
 	StationCount uint16
 
 	// Channel Utilization: Percentage of time (linearly scaled 0 to 255) that the AP sensed the medium was busy. Calculated only for the primary channel.
@@ -222,7 +222,7 @@ type BSS struct {
 	// The status of the client within the BSS.
 	Status BSSStatus
 
-	// The load element of the BSS (contains StationCount, ChannelUtilization and AvailableAdmissionCapacity).
+	// Load: The load element of the BSS (contains StationCount, ChannelUtilization and AvailableAdmissionCapacity).
 	Load BSSLoad
 }
 

--- a/wifi.go
+++ b/wifi.go
@@ -169,12 +169,12 @@ type StationInfo struct {
 	BeaconLoss int
 }
 
-// BSSLoad is an Information Element containing Measurements of the Load on the BSS
+// BSSLoad is an Information Element containing measurements of the load on the BSS.
 type BSSLoad struct {
 	// Version of the BSS Load Element. Can be 1 or 2.
 	Version int
 
-	// Station Count on this BSS
+	// Station Count on this BSS.
 	StationCount uint16
 
 	// Channel Utilization from 0 to 255
@@ -222,7 +222,7 @@ type BSS struct {
 	// The status of the client within the BSS.
 	Status BSSStatus
 
-	// BSSLoad elements
+	// The load element of the BSS (contains StationCount, ChannelUtilization and AvailableAdmissionCapacity).
 	Load BSSLoad
 }
 

--- a/wifi.go
+++ b/wifi.go
@@ -188,6 +188,19 @@ type BSS struct {
 
 	// The status of the client within the BSS.
 	Status BSSStatus
+
+	// BSSLoad elements
+	// Version of the BSS Load Element. Can be 1 or 2.
+	LoadVersion int
+
+	// Station Count on this BSS
+	LoadStationCount uint16
+
+	// Channel Utilization from 0 to 255
+	LoadChannelUtilization uint8
+
+	// Available Admission Capacity in unit [32 us/s]
+	LoadAvailableAdmissionCapacity uint16
 }
 
 // A BSSStatus indicates the current status of client within a BSS.
@@ -220,7 +233,8 @@ func (s BSSStatus) String() string {
 
 // List of 802.11 Information Element types.
 const (
-	ieSSID = 0
+	ieSSID    = 0
+	ieBSSLoad = 11
 )
 
 // An ie is an 802.11 information element.
@@ -232,7 +246,8 @@ type ie struct {
 
 // parseIEs parses zero or more ies from a byte slice.
 // Reference:
-//   https://www.safaribooksonline.com/library/view/80211-wireless-networks/0596100523/ch04.html#wireless802dot112-CHP-4-FIG-31
+//
+//	https://www.safaribooksonline.com/library/view/80211-wireless-networks/0596100523/ch04.html#wireless802dot112-CHP-4-FIG-31
 func parseIEs(b []byte) ([]ie, error) {
 	var ies []ie
 	var i int


### PR DESCRIPTION
This change extends the parsing of the Information Elements to include the QBSS-Load Element
* BSS-Load parameters are included in a custom struct (with proper `String()` Method)
* Supports both Versions (same as Wireshark) - See `func decodeBSSLoad(b []byte) (*BSSLoad, error)`
* Includes the Following Parameters of the QBSS-Load:
  * Station Count
  * Channel Utilization
  * Available Admission Capacity

Additionally the output of a failed test in `TestIntegrationLinuxConcurrent` has been extended. 

The program was tested solely for our own use cases, which might differ from yours. 
Especially I only tested in WLAN-Networks with QBBS Load Version 2 (Wireshark calls this "802.11e CCA Version").

Lukas Raffelt < lukas.raffelt@mercedes-benz.com > on behalf of Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

Licensed under MIT