### PR TITLE
Return an empty slice instead of an error if there is no station

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,9 @@ func (c *Client) BSS(ifi *Interface) (*BSS, error) {
 }
 
 // StationInfo retrieves all station statistics about a WiFi interface.
+//
+// Since v0.2.0: if there are no stations, an empty slice is returned instead
+// of an error.
 func (c *Client) StationInfo(ifi *Interface) ([]*StationInfo, error) {
 	return c.c.StationInfo(ifi)
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -184,10 +184,6 @@ func (c *client) StationInfo(ifi *Interface) ([]*StationInfo, error) {
 		return nil, err
 	}
 
-	if len(msgs) == 0 {
-		return nil, os.ErrNotExist
-	}
-
 	stations := make([]*StationInfo, len(msgs))
 	for i := range msgs {
 		if stations[i], err = parseStationInfo(msgs[i].Data); err != nil {

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -256,12 +256,15 @@ func TestLinux_clientStationInfoNoMessagesIsNotExist(t *testing.T) {
 		return nil, io.EOF
 	})
 
-	_, err := c.StationInfo(&Interface{
+	info, err := c.StationInfo(&Interface{
 		Index:        1,
 		HardwareAddr: net.HardwareAddr{0xe, 0xad, 0xbe, 0xef, 0xde, 0xad},
 	})
-	if !os.IsNotExist(err) {
-		t.Fatalf("expected is not exist, got: %v", err)
+	if err != nil {
+		t.Fatalf("undexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(info, []*StationInfo{}) {
+		t.Fatalf("expected info to be an empty slice, got %v", info)
 	}
 }
 


### PR DESCRIPTION
When there is no connected station, a strange "file does not exist" were previously returned. It seems this error is not relevant anymore, as [it was added when the API was only capable of returning a single StationInfo](https://github.com/mdlayher/wifi/commit/eb8b29b956ba5ff2fdd2d2f1f0b988b57fd3d8a3#diff-0003c45eee5373c4d29a20c6b0b5e111d2be2d48dbe36ab5a8d2543d93fa743e), and was not removed when [support for multiple station was added](https://github.com/mdlayher/wifi/commit/a04acdfd94b1d3296056cfb0855daacbaa983422#diff-0003c45eee5373c4d29a20c6b0b5e111d2be2d48dbe36ab5a8d2543d93fa743eR168). Now, an empty slice could simply be returned instead.
