### PR TITLE
Check if handshake offloading is supported

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -125,7 +125,7 @@ func (c *client) ConnectWPAPSK(ifi *Interface, ssid, psk string) error {
 		return err
 	}
 	if !support {
-		return errNotSupported
+		return ErrNotSupported
 	}
 
 	// Ask nl80211 to connect to the specified SSID with key..

--- a/client_linux.go
+++ b/client_linux.go
@@ -21,7 +21,7 @@ import (
 )
 
 // errNotSupported is returned when an operation is not supported
-var errNotSupported = errors.New("not supported")
+var ErrNotSupported = errors.New("not supported")
 
 // A client is the Linux implementation of osClient, which makes use of
 // netlink, generic netlink, and nl80211 to provide access to WiFi device


### PR DESCRIPTION
`ConnectWPAPSK()` only works if the driver supports handshake offloading (e.g. `brmfmac` on a Raspberry Pi with built-in WiFi). By checking support for this feature before attempting to connect, we can return a more descriptive error instead of `EINVAL`.

Closes: #54 