### PR TITLE
feat(conn): expose socket timeout methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,9 @@
 package wifi
 
+import (
+	"time"
+)
+
 // A Client is a type which can access WiFi device actions and statistics
 // using operating system-specific operations.
 type Client struct {
@@ -54,4 +58,19 @@ func (c *Client) BSS(ifi *Interface) (*BSS, error) {
 // of an error.
 func (c *Client) StationInfo(ifi *Interface) ([]*StationInfo, error) {
 	return c.c.StationInfo(ifi)
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+func (c *Client) SetDeadline(t time.Time) error {
+	return c.c.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline associated with the connection.
+func (c *Client) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline associated with the connection.
+func (c *Client) SetWriteDeadline(t time.Time) error {
+	return c.c.SetWriteDeadline(t)
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -195,6 +195,21 @@ func (c *client) StationInfo(ifi *Interface) ([]*StationInfo, error) {
 	return stations, nil
 }
 
+// SetDeadline sets the read and write deadlines associated with the connection.
+func (c *client) SetDeadline(t time.Time) error {
+	return c.c.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline associated with the connection.
+func (c *client) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline associated with the connection.
+func (c *client) SetWriteDeadline(t time.Time) error {
+	return c.c.SetWriteDeadline(t)
+}
+
 // get performs a request/response interaction with nl80211.
 func (c *client) get(
 	cmd uint8,

--- a/client_others.go
+++ b/client_others.go
@@ -6,6 +6,7 @@ package wifi
 import (
 	"fmt"
 	"runtime"
+	"time"
 )
 
 // errUnimplemented is returned by all functions on platforms that
@@ -24,3 +25,6 @@ func (*client) StationInfo(_ *Interface) ([]*StationInfo, error) { return nil, e
 func (*client) Connect(_ *Interface, _ string) error             { return errUnimplemented }
 func (*client) Disconnect(_ *Interface) error                    { return errUnimplemented }
 func (*client) ConnectWPAPSK(_ *Interface, _, _ string) error    { return errUnimplemented }
+func (*client) SetDeadline(t time.Time) error                    { return errUnimplemented }
+func (*client) SetReadDeadline(t time.Time) error                { return errUnimplemented }
+func (*client) SetWriteDeadline(t time.Time) error               { return errUnimplemented }


### PR DESCRIPTION
Allow cancelling specific blocking netlink I/O operations.

This is available in other netlink derivative libraries such as https://github.com/jsimonetti/rtnetlink, and it can be used to implement request specific cancellation support without closing the file descriptor.