### PR TITLE
chore(ci): update go versions and pin staticcheck

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - "1.20"
-        - "1.21"
+        - "1.22"
+        - "1.23"
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
 
       - name: Print staticcheck version
         run: staticcheck -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-        - "1.20"
-        - "1.21"
+        - "1.22"
+        - "1.23"
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/wifi
 
-go 1.20
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Staticcheck installs have a minimum Go version requirement that changes over time. Since the Go version is pinned, let's pin the matching staticcheck version so things don't break by itself over time.

"go install honnef.co/go/tools/cmd/staticcheck@latest" as of today requires at least Go 1.22.1.

- Update to use Go 1.22.
- Update tests to cover Go 1.22 / 1.23
- Pin staticcheck version to match Go versions