### PR TITLE
feat: add SurveyInfo

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,6 +60,9 @@ func (c *Client) StationInfo(ifi *Interface) ([]*StationInfo, error) {
 	return c.c.StationInfo(ifi)
 }
 
+// SurveyInfo retrieves the survey information about a WiFi interface.
+func (c *Client) SurveyInfo(ifi *Interface) ([]*SurveyInfo, error) { return c.c.SurveyInfo(ifi) }
+
 // SetDeadline sets the read and write deadlines associated with the connection.
 func (c *Client) SetDeadline(t time.Time) error {
 	return c.c.SetDeadline(t)

--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -73,6 +73,11 @@ func execN(t *testing.T, n int, expect []string, worker_id int) {
 				}
 			}
 
+			if _, err := c.SurveyInfo(ifi); err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					panicf("[worker_id %d; iteration %d] failed to retrieve survey info for device %s: %v", worker_id, i, ifi.Name, err)
+				}
+			}
 			names[ifi.Name]++
 		}
 	}

--- a/wifi.go
+++ b/wifi.go
@@ -304,3 +304,38 @@ func parseIEs(b []byte) ([]ie, error) {
 
 	return ies, nil
 }
+
+type SurveyInfo struct {
+	// The frequency in MHz of the channel.
+	Frequency int
+
+	// The noise level in dBm.
+	Noise int
+
+	// The time in milliseconds the radio has spent on this channel.
+	ChannelTime time.Duration
+
+	// The time in milliseconds the radio has spent on this channel while it was active.
+	ChannelTimeActive time.Duration
+
+	// The time in milliseconds the radio has spent on this channel while it was busy.
+	ChannelTimeBusy time.Duration
+
+	// The time in milliseconds the radio has spent on this channel while it was busy with external traffic.
+	ChannelTimeExtBusy time.Duration
+
+	// The time in milliseconds the radio has spent on this channel receiving data from a BSS.
+	ChannelTimeBssRx time.Duration
+
+	// The time in milliseconds the radio has spent on this channel receiving data.
+	ChannelTimeRx time.Duration
+
+	// The time in milliseconds the radio has spent on this channel transmitting data.
+	ChannelTimeTx time.Duration
+
+	// The time in milliseconds the radio has spent on this channel while it was scanning.
+	ChannelTimeScan time.Duration
+
+	// Indicates if the channel is currently in use.
+	InUse int
+}


### PR DESCRIPTION
This PR adds possibility to get a SurveyInfo for the interface

The data is the same as the output of the `iw IFACE survey dump`