### PR TITLE
Add methods to retrieve physical device information (Updated)

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ func (c *Client) BSS(ifi *Interface) (*BSS, error) {
 func (c *Client) PHYs() ([]*PHY, error) { return c.c.PHYs() }
 
 // PHY returns the WiFi device corresponding to the specified index.
-func (c *Client) PHY(index int) (*PHY, error) { return c.c.PHY(index) }
+func (c *Client) PHY(index uint32) (*PHY, error) { return c.c.PHY(index) }
 
 // StationInfo retrieves all station statistics about a WiFi interface.
 //

--- a/client.go
+++ b/client.go
@@ -52,6 +52,12 @@ func (c *Client) BSS(ifi *Interface) (*BSS, error) {
 	return c.c.BSS(ifi)
 }
 
+// PHYs returns a list of the system's WiFi devices.
+func (c *Client) PHYs() ([]*PHY, error) { return c.c.PHYs() }
+
+// PHY returns the WiFi device corresponding to the specified index.
+func (c *Client) PHY(index int) (*PHY, error) { return c.c.PHY(index) }
+
 // StationInfo retrieves all station statistics about a WiFi interface.
 //
 // Since v0.2.0: if there are no stations, an empty slice is returned instead

--- a/client_others.go
+++ b/client_others.go
@@ -20,6 +20,8 @@ func newClient() (*client, error) { return nil, errUnimplemented }
 
 func (*client) Close() error                                     { return errUnimplemented }
 func (*client) Interfaces() ([]*Interface, error)                { return nil, errUnimplemented }
+func (c *client) PHY(_ uint32) (*PHY, error)                     { return nil, errUnimplemented }
+func (c *client) PHYs() ([]*PHY, error)                          { return nil, errUnimplemented }
 func (*client) BSS(_ *Interface) (*BSS, error)                   { return nil, errUnimplemented }
 func (*client) StationInfo(_ *Interface) ([]*StationInfo, error) { return nil, errUnimplemented }
 func (*client) Connect(_ *Interface, _ string) error             { return errUnimplemented }

--- a/wifi.go
+++ b/wifi.go
@@ -360,6 +360,11 @@ type HTCapabilities struct {
 	// Maximum receivable A-MPDU (Aggregated MAC Protocol Data Unit) frame
 	// size.
 	MaxRxAMPDULength int
+
+	// Supported MCS for HT mode
+	// Todo:
+	// - Parse them are according to Section 7.3.2.56.4 IEEE 80211n
+	SupportedMCS [16]byte
 }
 
 // VHTCapabilities represents 802.11ac (Very High Throughput) capabilities.
@@ -432,6 +437,11 @@ type VHTCapabilities struct {
 	//Indicates whether the STA is capable of interpreting the Extended NSS BW
 	//Support subfield of the VHT Capabilities Information field.
 	ExtendedNSSBW int
+
+	// Supported MCS for VHT mode
+	// Todo:
+	// - Parse them according to Section 8.4.2.160.3 IEEE Std 80211ac-2013
+	SupportedMCS [8]byte
 }
 
 // FrequencyAttrs represents the attributes of a WiFi frequency/channel.

--- a/wifi.go
+++ b/wifi.go
@@ -291,6 +291,9 @@ type BandAttributes struct {
 	// High Throughput (802.11n) device capabilities (nil if not supported).
 	HTCapabilities *HTCapabilities
 
+	// Very High Throughput (802.11ac) device capabilities (nil if not supported).
+	VHTCapabilities *VHTCapabilities
+
 	// Minimum spacing between A-MPDU frames.  Used for both HT and VHT
 	// capable devices.
 	MinRxAMPDUSpacing time.Duration
@@ -357,6 +360,78 @@ type HTCapabilities struct {
 	// Maximum receivable A-MPDU (Aggregated MAC Protocol Data Unit) frame
 	// size.
 	MaxRxAMPDULength int
+}
+
+// VHTCapabilities represents 802.11ac (Very High Throughput) capabilities.
+//
+// The fields represent those in the VHT Capabilities element (802.11-2020,
+// 9.4.2.157).
+type VHTCapabilities struct {
+	// Maximum MPDU length supported by the device.
+	MaxMPDULength int
+
+	// Device supports 160MHz channel width.
+	VHT160 bool
+
+	// Device supports 80+80MHz channel width (non-contiguous 160MHz) along with 160MHz channel.
+	VHT8080 bool
+
+	// Device supports receiving Low Density Parity Check codes.
+	RXLDPC bool
+
+	// Device supports short guard intervals in 80MHz channels.
+	ShortGI80 bool
+
+	// Device supports short guard intervals in 160MHz and 80+80MHz channels.
+	ShortGI160 bool
+
+	// Device supports transmission of at least 2x1 Space-Time Block Coding transmission.
+	TXSTBC bool
+
+	// Number of STBC receive streams supported by the device. Valid values are 0-4.
+	RXSTBC int
+
+	// Device supports SU (Single User) Beamforming as a transmitter.
+	SuBeamFormer bool
+
+	// Device supports SU (Single User) Beamforming as a receiver.
+	SuBeamFormee bool
+
+	// Number of sounding antennas supported by the device for SU Beamforming transmission.
+	BFAntenna int
+
+	// Maximum sounding dimensions supported by the device for SU Beamforming.
+	SoundingDimension int
+
+	// Device supports MU (Multi-User) Beamforming as a transmitter.
+	MuBeamformer bool
+
+	// Device supports MU (Multi-User) Beamforming as a receiver.
+	MuBeamformee bool
+
+	// Device supports VHT TXOP power save mode.
+	VTHTXOPPS bool
+
+	// Device supports HT Control field when operating in VHT mode.
+	HTCVHT bool
+
+	// Maximum A-MPDU (Aggregated MAC Protocol Data Unit) frame size supported by the device.
+	MaxAMPDU int
+
+	// Device supports VHT Link Adaptation capabilities. Valid values
+	// specify the type of link adaptation supported (e.g., no feedback,
+	// unsolicited feedback, or both).
+	VHTLinkAdapt int
+
+	// Device supports receive antenna pattern consistency.
+	RXAntennaPattern bool
+
+	// Device supports transmit antenna pattern consistency.
+	TXAntennaPattern bool
+
+	//Indicates whether the STA is capable of interpreting the Extended NSS BW
+	//Support subfield of the VHT Capabilities Information field.
+	ExtendedNSSBW int
 }
 
 // FrequencyAttrs represents the attributes of a WiFi frequency/channel.

--- a/wifi.go
+++ b/wifi.go
@@ -3,6 +3,7 @@ package wifi
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/sys/unix"
 	"net"
 	"time"
 )
@@ -81,6 +82,8 @@ func (t InterfaceType) String() string {
 		return "station"
 	case InterfaceTypeAP:
 		return "access point"
+	case InterfaceTypeAPVLAN:
+		return "access point/VLAN"
 	case InterfaceTypeWDS:
 		return "wireless distribution"
 	case InterfaceTypeMonitor:
@@ -255,6 +258,216 @@ func (s BSSStatus) String() string {
 	default:
 		return fmt.Sprintf("unknown(%d)", s)
 	}
+}
+
+// A PHY represents the physical attributes of a wireless device.
+type PHY struct {
+	// The index of the interface.
+	Index int
+
+	// The name of the interface.
+	Name string
+
+	// The interface types this device supports.
+	SupportedIftypes []InterfaceType
+
+	// The software-only interface types this device supports.
+	SoftwareIftypes []InterfaceType
+
+	// An array of attributes related to each radio frequency band.
+	BandAttributes []BandAttributes
+
+	// A description of what combinations of interfaces the device can
+	// support running simultaneously, on virtual MACs.
+	InterfaceCombinations []InterfaceCombination
+
+	// All the attributes the kernel has told us about, but we haven't
+	// parsed.
+	Extra map[uint16][]byte
+}
+
+// BandAttributes represent the RF band-specific attributes.
+type BandAttributes struct {
+	// High Throughput (802.11n) device capabilities (nil if not supported).
+	HTCapabilities *HTCapabilities
+
+	// Minimum spacing between A-MPDU frames.  Used for both HT and VHT
+	// capable devices.
+	MinRxAMPDUSpacing time.Duration
+
+	// Per-frequency (channel) attributes.
+	FrequencyAttributes []FrequencyAttrs
+
+	// Per-bitrate attributes.
+	BitrateAttributes []BitrateAttrs
+}
+
+// HTCapabilities represents 802.11n (High Throughput) capabilities.  This group
+// of attributes is specific to each band of frequencies.  Failure to support
+// any given attribute may be due to lack support in the driver or the firmware,
+// not only in the hardware.  Some of them may also be overridden during station
+// association.
+//
+// The fields represent those in the HT Capabilities element (802.11-2016,
+// 9.4.2.56).  Notably missing is information about the device's Spatial
+// Multiplexing Power Save (SMPS) capability.  SMPS support must be determined
+// by retrieving the device feature flags (not yet supported).
+type HTCapabilities struct {
+	// Device supports Low Density Parity Check codes.
+	RxLDPC bool
+
+	// Device supports 40MHz channels (in addition to 20MHz channels).
+	CW40 bool
+
+	// Device supports HT Greenfield (802.11n-only) mode, in which a/b/g
+	// frames will be ignored.
+	HTGreenfield bool
+
+	// Device supports short guard intervals in 20MHz channels.
+	SGI20 bool
+
+	// Device supports short guard intervals in 40MHz channels.
+	SGI40 bool
+
+	// Device supports Space-Time Block Coding transmission.
+	TxSTBC bool
+
+	// Number of STBC receive streams supported by the device.  Valid values
+	// are 0-3.
+	RxSTBCStreams uint8
+
+	// Device supports delayed Block Ack frames when acknowledging an
+	// A-MPDU.
+	HTDelayedBlockAck bool
+
+	// Device supports long (7935 bytes) maximum A-MSDU length, compared to
+	// standard 3839 bytes.
+	LongMaxAMSDULength bool
+
+	// Device supports DSSS/CCK in 40MHz channels.
+	DSSSCCKHT40 bool
+
+	// (2.4GHz) Band cannot tolerate 40MHz channels because someone has
+	// requested it support 20MHz channels.
+	FortyMhzIntolerant bool
+
+	// Device supports L-SIG (non-HT) Transmit Oppportunity protection.
+	LSIGTxOPProtection bool
+
+	// Maximum receivable A-MPDU (Aggregated MAC Protocol Data Unit) frame
+	// size.
+	MaxRxAMPDULength int
+}
+
+// FrequencyAttrs represents the attributes of a WiFi frequency/channel.
+type FrequencyAttrs struct {
+	// Frequency is the radio frequency in MHz.
+	Frequency int
+
+	// Disabled indicates that the channel is disabled due to regulatory
+	// requirements.
+	Disabled bool
+
+	// NoIR indicates that no mechanisms that initiate radiation are
+	// permitted on this channel.
+	NoIR bool
+
+	// RadarDetection indicates that radar detection is mandatory on this
+	// channel.
+	RadarDetection bool
+
+	// MaxTxPower gives the maximum transmission power in mBm (100 * dBm).
+	MaxTxPower float32
+}
+
+// BitrateAttrs represents the attributes of a bitrate.
+type BitrateAttrs struct {
+	// Bitrate is the bitrate in units of 100kbps.
+	Bitrate float32
+
+	// ShortPreamble indicates that a short preamble is supported in the
+	// 2.4GHz band.
+	ShortPreamble bool
+}
+
+// InterfaceCombination represents a group of valid combinations of interface
+// types which can be simultaneously supported on a device.
+type InterfaceCombination struct {
+	CombinationLimits []InterfaceCombinationLimit
+
+	// Total is the maximum number of interfaces that can be created in this
+	// group.
+	Total int
+
+	// NumChannels is the number of different channels which may be used in
+	// this group.
+	NumChannels int
+
+	// StaApBiMatch indicates that beacon intervals within this group must
+	// all be the same, regardless of interface type.
+	StaApBiMatch bool
+}
+
+// InterfaceCombinationLimit represents a single combination of interface types
+// which may be run simultaneously on a device.
+type InterfaceCombinationLimit struct {
+	InterfaceTypes []InterfaceType
+
+	// Max is the maximum number of interfaces that can be chosen from the
+	// set of interface types in InterfaceTypes.
+	Max int
+}
+
+// FrequencyToChannel returns the channel number given the frequency in MHz, as
+// defined by IEEE802.11-2007, 17.3.8.3.2 and Annex J.
+func FrequencyToChannel(freq int) int {
+	if freq == 2484 {
+		return 14
+	} else if freq < 2484 {
+		return (freq - 2407) / 5
+	} else if freq >= 4910 && freq <= 4980 {
+		return (freq - 4000) / 5
+	} else if freq <= 45000 {
+		return (freq - 5000) / 5
+	} else if freq >= 58320 && freq <= 64800 {
+		return (freq - 56160) / 2160
+	} else {
+		return 0
+	}
+}
+
+// Constants representing the standard WiFi frequency bands.
+const (
+	Band2GHz  = unix.NL80211_BAND_2GHZ
+	Band5GHz  = unix.NL80211_BAND_5GHZ
+	Band60GHz = unix.NL80211_BAND_60GHZ
+)
+
+// ChannelToFrequency returns the frequency given the channel number and the
+// band, as there are overlapping channel numbers between bands.
+func ChannelToFrequency(channel int, band int) int {
+	if channel <= 0 {
+		return 0
+	}
+
+	switch band {
+	case Band2GHz:
+		if channel == 14 {
+			return 2484
+		} else if channel < 14 {
+			return 2407 + channel*5
+		}
+	case Band5GHz:
+		if channel >= 182 && channel <= 196 {
+			return 4000 + channel*5
+		}
+		return 5000 + channel*5
+	case Band60GHz:
+		if channel < 5 {
+			return 56160 + channel*2160
+		}
+	}
+	return 0
 }
 
 // List of 802.11 Information Element types.


### PR DESCRIPTION
Based on #17 by @dhduvall. It was very hard to rebase the 7 year old PR. So I created a new one here. Borrows most of the code from the old one.  
### Additions and changes
- Added parsing of VHTCapabilities
- Handles VHT MCS and HT MCS.
- Uses `"golang.org/x/sys/unix"` instead of `"github.com/mdlayher/wifi/internal/nl80211"`
- Uses `c.get` instead of `c.execute` wherever appropriate in `getPHYs()` 

As this PR includes the first lines of Go code I've written (and copied thanks to dhduvall). This will probably need some review :)  Suggestions for improvements are welcome!