### PR TITLE
Update Go versions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - "1.22"
         - "1.23"
+        - "1.24"
     runs-on: ubuntu-latest
 
     steps:
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           args: --verbose
-          version: v1.63.4
+          version: v1.64.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-        - "1.22"
         - "1.23"
+        - "1.24"
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/wifi
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
* Update minimum Go version to 1.23.x.
* Update CI to test latest 2 Go versions.