### PR TITLE
feat: make parse Interface and Station infos public

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -509,7 +509,6 @@ func parseGetScanResult(msgs []genetlink.Message) ([]*BSS, error) {
 }
 
 // parseInterfaces parses zero or more Interfaces from nl80211 interface
-// ParseInterfaces parses zero or more Interfaces from nl80211 interface
 // messages.
 func ParseInterfaces(msgs []genetlink.Message) ([]*Interface, error) {
 	ifis := make([]*Interface, 0, len(msgs))


### PR DESCRIPTION
This PR makes Interface and Station parsers public. This is helpful, when you use generic netlink to handle messages, but still need to parse WiFi mesasges