### PR TITLE
fix: Only run GetRegulatoryDatabase test if root

### DIFF
--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -184,6 +184,10 @@ func TestClient_SetRegulatoryRegion(t *testing.T) {
 }
 
 func TestClient_GetRegulatoryDomain(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skipf("skipping, must be run as root")
+	}
+
 	c, err := wifi.New()
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)


### PR DESCRIPTION
CI is currently broken - I missed checking if the user is root in one of the testst added in #162